### PR TITLE
Add user switching links if possible

### DIFF
--- a/includes/admin/members/edit-member.php
+++ b/includes/admin/members/edit-member.php
@@ -12,6 +12,9 @@ $member = new RCP_Member( $member_id );
 		<?php _e( 'Cancel', 'rcp' ); ?>
 	</a>
 </h2>
+<?php if( $switch_to_url = rcp_get_switch_to_url( $member->ID ) ) { ?>
+	<a href="<?php echo esc_url( $switch_to_url ); ?>" class="rcp_switch"><?php _e('Switch to User', 'rcp'); ?></a>
+<?php } ?>
 <form id="rcp-edit-member" action="" method="post">
 	<table class="form-table">
 		<tbody>

--- a/includes/admin/members/members-page.php
+++ b/includes/admin/members/members-page.php
@@ -172,6 +172,9 @@ function rcp_members_page() {
 									<?php } elseif( (isset($_GET['status']) && $_GET['status'] == 'active') || !isset($_GET['status'])) {  ?>
 										| <a href="<?php echo add_query_arg('deactivate_member', $member->ID, $current_page); ?>" class="rcp_deactivate"><?php _e('Deactivate', 'rcp'); ?></a>
 									<?php } ?>
+									<?php if( $switch_to_url = rcp_get_switch_to_url( $member->ID ) ) { ?>
+										| <a href="<?php echo esc_url( $switch_to_url ); ?>" class="rcp_switch"><?php _e('Switch to User', 'rcp'); ?></a>
+									<?php } ?>
 								<?php endif; ?>
 							</td>
 						</tr>

--- a/includes/class-rcp-member.php
+++ b/includes/class-rcp-member.php
@@ -457,4 +457,25 @@ class RCP_Member extends WP_User {
 
 	}
 
+	/**
+	 * Gets the URL to switch to the user
+	 * if the User Switching plugin is active
+	 *
+	 * @access public
+	 * @since 2.1
+	*/
+	public function get_switch_to_url() {
+
+		if( !class_exists( 'user_switching' ) ) return false;
+
+		$link = user_switching::maybe_switch_url( $this );
+		if ( $link ) {
+			$link = add_query_arg( 'redirect_to', urlencode( home_url() ), $link );
+			return $link;
+		}
+		else {
+			return false;
+		}
+	}
+
 }

--- a/includes/class-rcp-member.php
+++ b/includes/class-rcp-member.php
@@ -466,14 +466,15 @@ class RCP_Member extends WP_User {
 	*/
 	public function get_switch_to_url() {
 
-		if( !class_exists( 'user_switching' ) ) return false;
+		if( !class_exists( 'user_switching' ) ) {
+		   	return false;
+		}
 
 		$link = user_switching::maybe_switch_url( $this );
 		if ( $link ) {
 			$link = add_query_arg( 'redirect_to', urlencode( home_url() ), $link );
 			return $link;
-		}
-		else {
+		} else {
 			return false;
 		}
 	}

--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1062,7 +1062,9 @@ function rcp_member_can_update_billing_card( $user_id = 0 ) {
  */
 function rcp_get_switch_to_url( $user_id = 0 ) {
 
-	if( empty( $user_id ) ) return;
+	if( empty( $user_id ) ) {
+		return;
+	}
 
 	$member = new RCP_Member( $user_id );
 	return $member->get_switch_to_url();

--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1053,3 +1053,18 @@ function rcp_member_can_update_billing_card( $user_id = 0 ) {
 
 	return apply_filters( 'rcp_member_can_update_billing_card', $ret, $user_id );
 }
+
+/**
+ * Wrapper for RCP_Member->get_switch_to_url()
+ *
+ * @access public
+ * @since 2.1
+ */
+function rcp_get_switch_to_url( $user_id = 0 ) {
+
+	if( empty( $user_id ) ) return;
+
+	$member = new RCP_Member( $user_id );
+	return $member->get_switch_to_url();
+
+}


### PR DESCRIPTION
If the [user switching](https://wordpress.org/plugins/user-switching/) plugin is active, then user switching links will be displayed on the main members page and on each individual edit member page.

Fixes #129 