### PR TITLE
Show page IDs on settings select lists

### DIFF
--- a/includes/admin/settings/settings.php
+++ b/includes/admin/settings/settings.php
@@ -210,6 +210,7 @@ function rcp_settings_page() {
 										foreach ( $pages as $page ) {
 										  	$option = '<option value="' . $page->ID . '" ' . selected($page->ID, $rcp_options['registration_page'], false) . '>';
 											$option .= $page->post_title;
+											$option .= ' (ID: ' . $page->ID . ')';
 											$option .= '</option>';
 											echo $option;
 										}
@@ -232,6 +233,7 @@ function rcp_settings_page() {
 										foreach ( $pages as $page ) {
 										  	$option = '<option value="' . $page->ID . '" ' . selected($page->ID, $rcp_options['redirect'], false) . '>';
 											$option .= $page->post_title;
+											$option .= ' (ID: ' . $page->ID . ')';
 											$option .= '</option>';
 											echo $option;
 										}


### PR DESCRIPTION
Avoids ambiguity in case multiple pages share a title.

Fixes #130 