### PR TITLE
Use is_ssl() vs $_SERVER["HTTPS"] as it works behind most reverse pro…

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -243,7 +243,7 @@ function rcp_get_current_url() {
 	else :
 
 		$current_url = 'http';
-		if ( isset( $_SERVER["HTTPS"] ) && $_SERVER["HTTPS"] == "on" ) $current_url .= "s";
+		if ( is_ssl() ) $current_url .= "s";
 
 		$current_url .= "://";
 


### PR DESCRIPTION
…xies

Fixes an issue where RCP was adding :443 but not using https:// which caused a 400 Bad Request "The plain HTTP request was sent to HTTPS port" error.