### PR TITLE
Correct comment in includes/process-data.php

### DIFF
--- a/includes/process-data.php
+++ b/includes/process-data.php
@@ -3,7 +3,7 @@
 /*************************************************************************
 * this file processes all new subscription creations and updates
 * also manages adding/editings subscriptions to users
-* User registration and login is handled in handle-registration-login.php
+* User registration and login is handled in registration-functions.php
 **************************************************************************/
 function rcp_process_data() {
 


### PR DESCRIPTION
Comment was referencing a file that no longer exists as of https://github.com/pippinsplugins/Restrict-Content-Pro/commit/55373a7c90b6170f475fe85bf7d716b66d8fd683

Now correctly references includes/registration-functions.php