### PR TITLE
Remove requirement for  in order for Stripe customers to update their card

### DIFF
--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1236,7 +1236,7 @@ function rcp_member_can_update_billing_card( $user_id = 0 ) {
 	$profile_id = $member->get_payment_profile_id();
 
 	// Check if the member is a Stripe customer
-	if( false !== strpos( $profile_id, 'cus_' ) ) {
+	if( rcp_is_stripe_subscriber( $user_id ) ) {
 
 		$ret = true;
 

--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1233,18 +1233,15 @@ function rcp_member_can_update_billing_card( $user_id = 0 ) {
 	$ret    = false;
 	$member = new RCP_Member( $user_id );
 
-	if( $member->is_recurring() ) {
+	$profile_id = $member->get_payment_profile_id();
 
-		$profile_id = $member->get_payment_profile_id();
+	// Check if the member is a Stripe customer
+	if( false !== strpos( $profile_id, 'cus_' ) ) {
 
-		// Check if the member is a Stripe customer
-		if( false !== strpos( $profile_id, 'cus_' ) ) {
-
-			$ret = true;
-
-		}
+		$ret = true;
 
 	}
+
 
 	return apply_filters( 'rcp_member_can_update_billing_card', $ret, $user_id );
 }


### PR DESCRIPTION
I cannot think of any good reason that a Stripe member should only be able to update their card details if `$recurring == true`. 

I've had a number of times where a member has expired due to a failed card, where I'd like to be able to reactivate them on their behalf after they update their card details. This is not currently possible though because `$recurring` gets set to false upon expiration. 

Thoughts @pippinsplugins?