### PR TITLE
Introduce payment-functions.php file and function to check for existing payments by ID

### DIFF
--- a/includes/payment-functions.php
+++ b/includes/payment-functions.php
@@ -1,0 +1,18 @@
+<?php 
+/**
+ * Check if a payment already exists
+ *
+ * @access      private
+ * @param       $transaction_id string/date The unique ID associated with the transaction
+ * @return      bool
+*/
+
+function rcp_check_for_existing_payment_by_id( $transaction_id ) {
+
+	global $wpdb, $rcp_payments_db_name;
+
+	if( $wpdb->get_results( $wpdb->prepare("SELECT id FROM " . $rcp_payments_db_name . " WHERE `transaction_id`='%s';", $transaction_id ) ) )
+		return true; // this payment already exists
+
+	return false; // this payment doesn't exist
+}

--- a/restrict-content-pro.php
+++ b/restrict-content-pro.php
@@ -173,6 +173,7 @@ if( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 	include( RCP_PLUGIN_DIR . 'includes/member-forms.php' );
 	include( RCP_PLUGIN_DIR . 'includes/member-functions.php' );
 	include( RCP_PLUGIN_DIR . 'includes/misc-functions.php' );
+	include( RCP_PLUGIN_DIR . 'includes/payment-functions.php' );
 	include( RCP_PLUGIN_DIR . 'includes/registration-functions.php' );
 	include( RCP_PLUGIN_DIR . 'includes/subscription-functions.php' );
 	include( RCP_PLUGIN_DIR . 'includes/error-tracking.php' );


### PR DESCRIPTION
This introduces a new `payment-functions.php` file, since all current payment functions are depreciated. In addition this adds a new `rcp_check_for_existiing_payment_by_id()` function that only compares the unique transaction ID to determine if a payment exists in the RCP database already. 

The previous function, depreciated, function `rcp_check_for_existing_payment()` used the `$type`, `$date`, and `$subscription_key` to compare payments. This actually resulted in duplicate (yet incomplete payment) entries in some scenarios. One example is in the work I'm doing for #233, where it would sometimes create up to 6 payment entries, with only the last one being complete.

Addresses #271 
