### PR TITLE
Remove condition with empty( CONSTANT ) check

### DIFF
--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1196,9 +1196,7 @@ function rcp_can_member_cancel( $user_id = 0 ) {
 
 		} elseif ( rcp_is_2checkout_subscriber( $user_id ) && defined( 'TWOCHECKOUT_ADMIN_USER' ) && defined( 'TWOCHECKOUT_ADMIN_PASSWORD' ) ) {
 
-			if ( ! empty( TWOCHECKOUT_ADMIN_USER ) && ! empty( TWOCHECKOUT_ADMIN_PASSWORD ) ) {
 				$ret = true;
-			}
 
 		}
 


### PR DESCRIPTION
In PHP empty() does not support checking a constant. It only allows variables and expressions. This will cause PHP to throw an error expecting :: as it is looking for an object with the name TWOCHECKOUT_ADMIN_USER and TWOCHECKOUT_ADMIN_PASSWORD. Because the defined() check is above this empty() check may be redundant. If the user does put an empty string in then using the constant would fail, just as it would if they input an invalid password.